### PR TITLE
Drop nodeSelector from alertmanager roles

### DIFF
--- a/deploy/roles/deploy.builder/templates/service-assurance/alertmanager/alertmanager.yaml
+++ b/deploy/roles/deploy.builder/templates/service-assurance/alertmanager/alertmanager.yaml
@@ -4,8 +4,6 @@ metadata:
   name: sa
 spec:
   version: v0.15.0
-  nodeSelector:
-    application: sa-telemetry
   podMetadata:
     labels:
       app: alertmanager


### PR DESCRIPTION
Without this Alertmanager pod just sits in pending state due to FailedScheduling