### PR TITLE
Initial smoke test idea

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -2,13 +2,16 @@
 
 Here are some artifacts to assist with testing the SAF after it is deployed.
 
-Currently this is just a "smoke test" that runs internal to the OCP cluster. It delivers collectd data to the SAF amqp node and verifies that it can be seen in prometheus. This is intended to be usable for developers and TravisCI to validate our builds before merging changes to this repo.
+Currently this is just a "smoke test" that runs internal to the OCP cluster. It
+delivers collectd data to the SAF amqp node and verifies that it can be seen in
+prometheus. This is intended to be usable for developers and TravisCI to
+validate our builds before merging changes to this repo.
 
 ## Usage
 
 1. Have `oc` pointing at your sa-telemetry project and run `./smoketest.sh`
 1. Run `oc get jobs` and check the result of the saf-smoketest job
-1. (If necesarry) Check the logs of the saf-smoketest pod
+1. (If necessary) Check the logs of the saf-smoketest pod
 
 ### Example
 
@@ -45,7 +48,9 @@ Initialization complete, entering read-loop.
 
 These are some things that would make this better:
 
-* Would like to actually test via the AMQP+TLS interface as the system boundary instead of directly to the internal AMQP broker
+* Would like to actually test via the AMQP+TLS interface as the system boundary
+  instead of directly to the internal AMQP broker
   * Option to do internal vs. external
 * Looks for just any metrics, so you have to reset prometheus to re-test.
-  * Would be better to check for metrics specifically from the test harness specifically in the testing timeframe
+  * Would be better to check for metrics specifically from the test harness
+    specifically in the testing timeframe

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,51 @@
+# SAF Testing notes
+
+Here are some artifacts to assist with testing the SAF after it is deployed.
+
+Currently this is just a "smoke test" that runs internal to the OCP cluster. It delivers collectd data to the SAF amqp node and verifies that it can be seen in prometheus. This is intended to be usable for developers and TravisCI to validate our builds before merging changes to this repo.
+
+## Usage
+
+1. Have `oc` pointing at your sa-telemetry project and run `./smoketest.sh`
+1. Run `oc get jobs` and check the result of the saf-smoketest job
+1. (If necesarry) Check the logs of the saf-smoketest pod
+
+### Example
+
+```
+$ ./smoketest.sh
+configmap "saf-smoketest-collectd-config" deleted
+configmap "saf-smoketest-entrypoint-script" deleted
+job.batch "saf-smoketest" deleted
+configmap/saf-smoketest-collectd-config created
+configmap/saf-smoketest-entrypoint-script created
+job.batch/saf-smoketest created
+
+$ oc get jobs
+NAME            DESIRED   SUCCESSFUL   AGE
+saf-smoketest   1         1            18s
+
+$ oc get pods -l name=saf-smoketest
+NAME                  READY     STATUS      RESTARTS   AGE
+saf-smoketest-md967   0/1       Completed   0          18s
+
+$ oc logs saf-smoketest-md967
+Sleeping for 3 seconds waiting for collectd to enter read-loop
+plugin_load: plugin "cpu" successfully loaded.
+plugin_load: plugin "amqp1" successfully loaded.
+Initialization complete, entering read-loop.
+Initialization complete, entering read-loop.
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   328  100   262  100    66  16926   4263 --:--:-- --:--:-- --:--:-- 17466
+{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"sa_collectd_cpu_total","cpu":"0","endpoint":"metrics","exported_instance":"saf-smoketest-md967","service":"white-smartgateway","type":"user"},"value":[1562363042.123,"518777"]}]}}
+```
+
+## Improvements
+
+These are some things that would make this better:
+
+* Would like to actually test via the AMQP+TLS interface as the system boundary instead of directly to the internal AMQP broker
+  * Option to do internal vs. external
+* Looks for just any metrics, so you have to reset prometheus to re-test.
+  * Would be better to check for metrics specifically from the test harness specifically in the testing timeframe

--- a/tests/minimal-collectd.conf
+++ b/tests/minimal-collectd.conf
@@ -1,0 +1,16 @@
+Interval 1
+
+LoadPlugin cpu
+LoadPlugin amqp1
+
+<Plugin "amqp1">
+  <Transport "name">
+    Host "qdr-white.sa-telemetry.svc.cluster.local"
+    Port "5672"
+    Address "collectd"
+    <Instance "telemetry">
+        Format JSON
+        PreSettle true
+    </Instance>
+  </Transport>
+</Plugin>

--- a/tests/smoketest.sh
+++ b/tests/smoketest.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Runs on the dev/CI machine to execute the test harness job in the cluster
+# Requires:
+#   oc tools pointing at your SAF instance
+oc delete configmap/saf-smoketest-collectd-config configmap/saf-smoketest-entrypoint-script job/saf-smoketest || true
+
+oc create configmap saf-smoketest-collectd-config --from-file=collectd.conf=./minimal-collectd.conf
+oc create configmap saf-smoketest-entrypoint-script --from-file ./smoketest_entrypoint.sh
+oc create -f smoketest_job.yaml

--- a/tests/smoketest_entrypoint.sh
+++ b/tests/smoketest_entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# Executes inside the test harness container to start collectd and look for resulting metrics in prometheus
+PROMETHEUS=${PROMETHEUS:-"prometheus-operated.sa-telemetry.svc.cluster.local:9090"}
+
+# Run collectd in foreground mode to generate some metrics
+/usr/sbin/collectd -f 2>&1 | tee /tmp/collectd_output &
+
+# Wait until collectd appears to be up and running
+retries=3
+until [ $retries -eq 0 ] || grep "Initialization complete, entering read-loop" /tmp/collectd_output; do
+  retries=$[$retries-1]
+  echo "Sleeping for 3 seconds waiting for collectd to enter read-loop"
+  sleep 3
+done
+
+# Checks that the metrics actually appear in prometheus
+# The egrep exit code is the result of the test and becomes the container/pod/job exit code
+curl -g "${PROMETHEUS}/api/v1/query?" --data-urlencode 'query=sa_collectd_cpu_total{cpu="0",type="user"}' \
+   | egrep '"result":\[{"metric":{"__name__":"sa_collectd_cpu_total","cpu":"0","endpoint":"metrics","exported_instance":"saf-smoketest-.*","service":"white-smartgateway","type":"user"},"value":\[.+,".+"\]'

--- a/tests/smoketest_job.yaml
+++ b/tests/smoketest_job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: saf-smoketest
+spec:
+  parallelism: 1
+  completions: 1
+spec:
+  template:
+    metadata:
+      labels:
+        name: saf-smoketest
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: smoketest
+          image: tripleomaster/centos-binary-collectd:current-tripleo-rdo
+          command:
+            - /smoketest_entrypoint.sh
+          volumeMounts:
+          - name: collectd-config
+            mountPath: /etc/collectd.conf
+            subPath: collectd.conf
+          - name: entrypoint-script
+            mountPath: /smoketest_entrypoint.sh
+            subPath: smoketest_entrypoint.sh
+      volumes:
+      - name: collectd-config
+        configMap:
+          name: saf-smoketest-collectd-config
+      - name: entrypoint-script
+        configMap:
+          name: saf-smoketest-entrypoint-script
+          defaultMode: 0555


### PR DESCRIPTION
* Runs collectd w/ amqp1 plugin inside the saf-telemetry namespace in the cluster
* Collects CPU metrics and pushes it to the bus
* Checks for those CPU metrics (okay, ANY cpu data at the moment) in prometheus
* This validates the qdr router, smart gateway, and prometheus typically in under 10s