### PR TITLE
Use specific container images for SGO and SG

### DIFF
--- a/deploy/import-downstream.sh
+++ b/deploy/import-downstream.sh
@@ -27,7 +27,7 @@ oc import-image amq-interconnect-operator:latest --from=registry.redhat.io/amq7-
 
 # Currently we don't have a robust release process for the Smart Gateway or
 # corresponding Operator, so we just pull the latest version down for now.
-oc import-image smart-gateway:latest --from=registry.redhat.io/saf/smart-gateway:latest --confirm
-oc import-image smart-gateway-operator:latest --from=registry.redhat.io/saf/smart-gateway-operator:latest --confirm
+oc import-image smart-gateway:latest --from=registry.redhat.io/saf/smart-gateway:1.0-3 --confirm
+oc import-image smart-gateway-operator:latest --from=registry.redhat.io/saf/smart-gateway-operator:1.0-3 --confirm
 
 oc set image-lookup prometheus prometheus-operator prometheus-configmap-reloader prometheus-config-reloader prometheus-alertmanager amq-interconnect amq-interconnect-operator smart-gateway smart-gateway-operator


### PR DESCRIPTION
Use a specific container image version tag for the Smart Gateway and Smart
Gateway Operator in order to avoid using the 'latest' container image tag.