### PR TITLE
Quickstart supports downstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
 
 script:
 - cd deploy
-- ./quickstart_upstream.sh
+- ./quickstart.sh
 - cd ../tests
 - ./smoketest.sh

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -134,6 +134,8 @@ EOSM
 # create the objects
 if [ "$method" == "CREATE" ]; then
     echo "  * [ii] Creating the operators" ; create "${operator_list[@]}"
+    echo "  * [ii] Waiting for prometheus-operator deployment to complete"
+    until oc rollout status dc/prometheus-operator; do sleep 3; done
     echo ""
     echo "+---------------------------------------------------+"
     echo "| Waiting for CRDs to become established in the API |"

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -7,19 +7,6 @@
 oc login -u system:admin
 oc new-project sa-telemetry
 
-
-# import container images
-if [[ "$*" =~ --downstream-secret=(.*) ]]; then
-    echo "Importing containers from downstream"
-    eval secret_file="${BASH_REMATCH[1]}"  # eval is for ~ expansion
-    # shellcheck disable=SC2154
-    oc create -f "${secret_file}"
-    ./import-downstream.sh
-else
-    echo "Importing containers from upstream"
-    ./import-upstream.sh
-fi
-
 openssl req -new -x509 -batch -nodes -days 11000 \
         -subj "/O=io.interconnectedcloud/CN=qdr-white.sa-telemetry.svc.cluster.local" \
         -out qdr-server-certs/tls.crt \
@@ -37,7 +24,9 @@ oc patch node localhost -p '{"metadata":{"labels":{"application": "sa-telemetry"
 # import container images
 if [[ "$*" =~ --downstream-secret=(.*) ]]; then
     echo "Importing containers from downstream"
-    oc create -f ${BASH_REMATCH[1]}
+    eval secret_file="${BASH_REMATCH[1]}"  # eval is for ~ expansion
+    # shellcheck disable=SC2154
+    oc create -f "${secret_file}"
     ./import-downstream.sh
 else
     echo "Importing containers from upstream"


### PR DESCRIPTION
* Re-added wait for prometheus-operator to cut down on CRD wait spam

## Testing
```
[csibbitt@laptop deploy (csibbitt-594-downstream-tests) ]$ ./quickstart.sh --downstream-secret=~/6340056-cloudops-pull-secret.yaml 
[...]
Importing containers from downstream
secret/6340056-cloudops-pull-secret created
[...]
Docker Image:   registry.redhat.io/openshift3/prometheus@sha256:b0df6a353ecc3b210710151ef370b241c55912b3b3bd21ac98fc6418b4708d01
[...]
[csibbitt@laptop tests (csibbitt-594-downstream-tests) ]$ ./smoketest.sh 
[...]
*** [SUCCESS] Smoke test job completed successfully
```

Travis tested the other case