### PR TITLE
Change label `smartgateway: white` to `app: smart-gateway`

### DIFF
--- a/deploy/service-assurance/prometheus/prometheus.yaml
+++ b/deploy/service-assurance/prometheus/prometheus.yaml
@@ -29,7 +29,7 @@ spec:
   serviceAccountName: prometheus-sa
   serviceMonitorSelector:
     matchLabels:
-      smartgateway: white
+      app: smart-gateway
   storage:
     class: ""
     resources: {}


### PR DESCRIPTION
This is compatible with the current smart-gateway-operator master branch: https://github.com/redhat-service-assurance/smart-gateway-operator/blob/master/roles/smartgateway/tasks/main.yml#L81