### PR TITLE
Allow for SAF to coexist with openshift-monitoring

### DIFF
--- a/deploy/import-downstream.sh
+++ b/deploy/import-downstream.sh
@@ -6,14 +6,14 @@
 
 # Version v2.11.0 is here because the Prometheus Operator in use requires a
 # major version of '2' and the version format of vMajor.Minor.Patch
-oc import-image prometheus:v2.11.0 --from=registry.redhat.io/openshift3/prometheus:v3.11.104-14 --confirm
-oc import-image prometheus-operator:latest --from=registry.redhat.io/openshift3/ose-prometheus-operator:v3.11.104-14 --confirm
-oc import-image prometheus-configmap-reloader:latest --from=registry.redhat.io/openshift3/ose-configmap-reloader:v3.11.104-14 --confirm
-oc import-image prometheus-config-reloader:latest --from=registry.redhat.io/openshift3/ose-prometheus-config-reloader:v3.11.104-14 --confirm
+oc import-image prometheus:latest --from=registry.redhat.io/openshift3/prometheus:v3.11 --confirm
+oc import-image prometheus-operator:latest --from=registry.redhat.io/openshift3/ose-prometheus-operator:v3.11 --confirm
+oc import-image prometheus-configmap-reloader:latest --from=registry.redhat.io/openshift3/ose-configmap-reloader:v3.11 --confirm
+oc import-image prometheus-config-reloader:latest --from=registry.redhat.io/openshift3/ose-prometheus-config-reloader:v3.11 --confirm
 
 # Deployment of the Prometheus Alertmanager from the Operator also requires a
 # specific version format which effectively assumes a version of 0.15.0.
-oc import-image prometheus-alertmanager:v0.15.0 --from=registry.redhat.io/openshift3/prometheus-alertmanager:v3.11.104-14 --confirm
+oc import-image prometheus-alertmanager:v0.15.0 --from=registry.redhat.io/openshift3/prometheus-alertmanager:v3.11 --confirm
 
 # Version 1.4-6 here is used to reference the expected downstream version from
 # the template and to provide some additional context for understanding the
@@ -28,6 +28,6 @@ oc import-image amq-interconnect-operator:latest --from=registry.redhat.io/amq7-
 # Currently we don't have a robust release process for the Smart Gateway or
 # corresponding Operator, so we just pull the latest version down for now.
 oc import-image smart-gateway:latest --from=registry.redhat.io/saf/smart-gateway:1.0-3 --confirm
-oc import-image smart-gateway-operator:latest --from=registry.redhat.io/saf/smart-gateway-operator:1.0-3 --confirm
+oc import-image smart-gateway-operator:latest --from=registry.redhat.io/saf/smart-gateway-operator:1.0-4 --confirm
 
 oc set image-lookup prometheus prometheus-operator prometheus-configmap-reloader prometheus-config-reloader prometheus-alertmanager amq-interconnect amq-interconnect-operator smart-gateway smart-gateway-operator

--- a/deploy/import-upstream.sh
+++ b/deploy/import-upstream.sh
@@ -5,7 +5,7 @@
 
 # Version v2.11.0 is here because the Prometheus Operator in use requires a
 # major version of '2' and the version format of vMajor.Minor.Patch
-oc import-image prometheus:v2.11.0 --from=quay.io/openshift/origin-prometheus:v3.11 --confirm
+oc import-image prometheus:latest --from=quay.io/openshift/origin-prometheus:v3.11 --confirm
 oc import-image prometheus-operator:latest --from=quay.io/openshift/origin-prometheus-operator:v3.11 --confirm
 oc import-image prometheus-configmap-reloader:latest --from=quay.io/openshift/origin-configmap-reload:v3.11 --confirm
 oc import-image prometheus-config-reloader:latest --from=quay.io/openshift/origin-prometheus-config-reloader:v3.11 --confirm

--- a/deploy/operators/prometheus/clusterrole.yaml
+++ b/deploy/operators/prometheus/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-operator
+  name: prometheus-operator-sa-telemetry
 rules:
 - apiGroups:
   - extensions

--- a/deploy/operators/prometheus/clusterrolebinding.yaml
+++ b/deploy/operators/prometheus/clusterrolebinding.yaml
@@ -2,10 +2,9 @@ apiVersion: authorization.openshift.io/v1
 groupNames: null
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-operator
-  uid: 15c20379-50e4-11e9-b068-566fc8c20003
+  name: prometheus-operator-sa-telemetry
 roleRef:
-  name: prometheus-operator
+  name: prometheus-operator-sa-telemetry
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator

--- a/deploy/roles/deploy.builder/defaults/main.yml
+++ b/deploy/roles/deploy.builder/defaults/main.yml
@@ -2,3 +2,4 @@
 registry_path: docker-registry.default.svc:5000
 imagestream_namespace: sa-telemetry
 alertmanager_replicas: 1
+prometheus_pvc_storage_request: 20G

--- a/deploy/roles/deploy.builder/tasks/main.yml
+++ b/deploy/roles/deploy.builder/tasks/main.yml
@@ -6,6 +6,7 @@
     - operators/prometheus/operator.yaml
     - operators/qdrouterd/operator.yaml
     - operators/smartgateway/operator.yaml
+    - service-assurance/prometheus/prometheus.yaml
     - service-assurance/alertmanager/alertmanager.yaml
     - service-assurance/qdrouterd/qdrouterd.yaml
     - service-assurance/smartgateway/smartgateway.yaml

--- a/deploy/roles/deploy.builder/templates/operators/prometheus/operator.yaml
+++ b/deploy/roles/deploy.builder/templates/operators/prometheus/operator.yaml
@@ -32,6 +32,7 @@ spec:
         - --alertmanager-default-base-image={{ registry_path }}/{{ imagestream_namespace }}/prometheus-alertmanager
         - --prometheus-config-reloader={{ registry_path }}/{{ imagestream_namespace }}/prometheus-config-reloader:latest
         - --prometheus-default-base-image={{ registry_path }}/{{ imagestream_namespace }}/prometheus
+        - --namespace=sa-telemetry
         image: {{ registry_path }}/{{ imagestream_namespace }}/prometheus-operator
         imagePullPolicy: IfNotPresent
         name: prometheus-operator

--- a/deploy/roles/deploy.builder/templates/service-assurance/prometheus/prometheus.yaml
+++ b/deploy/roles/deploy.builder/templates/service-assurance/prometheus/prometheus.yaml
@@ -4,7 +4,9 @@ metadata:
   name: white
   namespace: sa-telemetry
 spec:
-  version: v2.11.0
+  version: v2.3.2
+  tag: latest
+  baseImage: {{ registry_path }}/{{ imagestream_namespace }}/prometheus
   alerting:
     alert_relabel_configs:
     - regex: (.+)\d+
@@ -38,4 +40,4 @@ spec:
       spec:
         resources:
           requests:
-            storage: 20G
+            storage: {{ prometheus_pvc_storage_request }}

--- a/tests/install-and-run-ocp.sh
+++ b/tests/install-and-run-ocp.sh
@@ -5,6 +5,7 @@
 OC_VER=v3.11.0
 OC_HASH=0cbc58b
 OC_NAME="openshift-origin-client-tools-${OC_VER}-${OC_HASH}-linux-64bit"
+
 wget https://github.com/openshift/origin/releases/download/${OC_VER}/${OC_NAME}.tar.gz
 tar -xvzf ${OC_NAME}.tar.gz
 sudo mv ${OC_NAME}/oc /usr/local/bin/


### PR DESCRIPTION
These changes are related to work done to deploy SAF into an
environment where OpenShift Monitoring has been deployed. The current
way prior to this change would result in overlapping namespaces for
the ClusterRole and ClusterRoleBinding.

Additionally, Prometheus Operator has been setup to be namespace
bound, and will not act on requests for Prometheus objects that
haven't been created in this namespace.

A new parameter has been added (defaulted to existing 20G sizing) of
the PVC request by Prometheus. Allows for using smaller or larger PVC
requests now.

Downstream and upstream versions have been updated to reflect the new
method that allows us to use a different tag name from that of the
version which makes the tagging slightly less confusing.

Removed the static prometheus.yaml since it is now being generated by
the deploy_builder.yaml via Ansible.

Closes #44