### PR TITLE
Changes required to get this working in my env

### DIFF
--- a/tests/performance-test/Dockerfile
+++ b/tests/performance-test/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.12.7
 WORKDIR /go/src/performance-test/
 
-COPY ./dashboard.go ./main.go ./parser.go .
+COPY ./dashboard.go ./main.go ./parser.go ./
 
 RUN go get gopkg.in/yaml.v2 && \
     go get github.com/grafana-tools/sdk && \
@@ -18,5 +18,4 @@ RUN yum install golang -y && \
     yum clean all
 
 COPY --from=0 /tmp/main /performance-test/exec/main
-COPY grafana/apikey /performance-test/grafana/apikey
 COPY deploy/scripts/unit-test.sh /performance-test/exec/unit-test.sh

--- a/tests/performance-test/deploy/README.md
+++ b/tests/performance-test/deploy/README.md
@@ -2,39 +2,39 @@
 
 ## Environment
 
-minishift v1.34.1   
+minishift v1.34.1
 docker v17.05+
 
 ### Setup
-SAF must already be deployed on a local minishift with the registry-route addon 
-enabled. A quick way to do this is using the `quickstart.sh` script in 
+SAF must already be deployed on a local minishift with the registry-route addon
+enabled. A quick way to do this is using the `quickstart.sh` script in
 `telemetry-framework/deploy/` directory to run SAF upstream version (quickstart
  can also be used to deploy the downstream):
 
-```shell 
+```shell
 $ minishift addons enable registry-route   # Run BEFORE starting minishift
 $ minishift start
-$ eval $(minishift oc-env)                 
+$ eval $(minishift oc-env)
 $ cd $WORKDIR/telemetry-framework/deploy/; ./quickstart.sh
 ```
-More details about deploying SAF on Minishift can be found in the 
+More details about deploying SAF on Minishift can be found in the
 [SAF deployment docs](../../../deploy/)
 
 The Minishift registry needs to be configured such that a local docker image can
 be pushed to it. To do this, a new account must be created on Minishift that has
-admin privledges. The default admin account cannot be used because it does not 
+admin privledges. The default admin account cannot be used because it does not
 provide a token with which to login to the registry with docker.
 
 ```shell
 $ oc login -u developer -p passwd   # create new user if it does not already exist
-$ oc login -u system:admin 
+$ oc login -u system:admin
 $ oc adm policy add-cluster-role-to-user cluster-admin developer  # give user admin privlidges
 $ oc login -u developer -p passwd
 $ oc project sa-telemetry          # must use same project as SAF
 ```
 ## Build
 
-Minishift does not have an up-to-date version of docker and cannot execute 
+Minishift does not have an up-to-date version of docker and cannot execute
 multistage builds. As a result, the performance test image must be built locally
 with docker v17.05 or higher and pushed to the minshift internal docker registry.
 
@@ -49,7 +49,7 @@ $ sudo systemctl restart docker
 $ docker login -u developer -p $(oc whoami -t) $(minishift openshift registry) # log in to registry
 ```
 
-Check that docker is using the new registry - the address should match that 
+Check that docker is using the new registry - the address should match that
 shown by `oc get routes -n default`
 ```shell
 $ docker info
@@ -67,10 +67,10 @@ $ DOCKER_IMAGE="$(minishift openshift registry)/$(oc project -q)/performance-tes
 $ docker build -t $DOCKER_IMAGE .
 $ docker push $DOCKER_IMAGE   #sometimes this needs to be run more than once
 ```
-Note: if an earlier version of the performance test image has been previously 
-uploaded to the Minishift registry, the previous image stream and associated 
-containers must be deleted before pushing up the new version else it will not 
-be properly updated. Refer to the `performance-test/docker-push.sh` steps to 
+Note: if an earlier version of the performance test image has been previously
+uploaded to the Minishift registry, the previous image stream and associated
+containers must be deleted before pushing up the new version else it will not
+be properly updated. Refer to the `performance-test/docker-push.sh` steps to
 do that.
 
 
@@ -84,20 +84,20 @@ to be done once:
 $ cd $WORKDIR/telemetry-framework/tests/performance-test/deploy
 $ ./grafana-launcher.sh
 ```
-The grafana launcher script will output a URL that can be used to log into the 
-dashboard. This Grafana instance has all authentication disabled - if, in the 
+The grafana launcher script will output a URL that can be used to log into the
+dashboard. This Grafana instance has all authentication disabled - if, in the
 future, the performance test should report to an authenticated grafana instance,
-the test scripts must be modified. Once the Grafana instance is running, launch 
+the test scripts must be modified. Once the Grafana instance is running, launch
 the performance test OpenShift job:
 
 ```shell
 $ ./performance-test.sh
 ```
 
-This will run all of the tests specified in the test-configs.yaml file in 
+This will run all of the tests specified in the test-configs.yaml file in
 sequence.
 
-Monitor the performance test status by watching the job with 
-`oc get job performance-test-job -w`. The job will run for the sum of the lengths
-of all of the tests in the test-config file. Logs can be viewed with 
-`oc logs -f performance-test-<unique-pod-id>` 
+Monitor the performance test status by watching the job with
+`oc get job saf-performance-test -w`. The job will run for the sum of the lengths
+of all of the tests in the test-config file. Logs can be viewed with
+`oc logs -f saf-performance-test-<unique-pod-id>`

--- a/tests/performance-test/deploy/config/.gitignore
+++ b/tests/performance-test/deploy/config/.gitignore
@@ -1,0 +1,1 @@
+hosts.json

--- a/tests/performance-test/deploy/config/hosts.json
+++ b/tests/performance-test/deploy/config/hosts.json
@@ -1,1 +1,0 @@
-{"grafana-host":"grafana-sa-telemetry.192.168.42.143.nip.io","prometheus-host":"prometheus-sa-telemetry.192.168.42.143.nip.io"}

--- a/tests/performance-test/deploy/scripts/performance-test-entrypoint.sh
+++ b/tests/performance-test/deploy/scripts/performance-test-entrypoint.sh
@@ -15,7 +15,7 @@ echo "Launching collectd"
 /usr/sbin/collectd -f 2>&1 &
 sleep 1
 echo "Retrieving API token for Grafana"
-curl -X POST -H "Content-Type: application/json" -d '{"name":"apikeycurl", "role": "Admin"}' "$GRAFANA_URL/api/auth/keys" > /performance-test/grafana/apikey
+curl -X POST -H "Content-Type: application/json" -d '{"name":"apikeycurl", "role": "Admin"}' "$GRAFANA_URL/api/auth/keys" > /tmp/grafana_apikey
 
 echo "Launching performance tests"
 /performance-test/exec/main

--- a/tests/performance-test/main.go
+++ b/tests/performance-test/main.go
@@ -33,7 +33,7 @@ func (pt *PerformanceTest) InitDashboard(title string) {
 	pt.db = new(Dashboard)
 
 	var data []byte
-	data, pt.err = ioutil.ReadFile("/performance-test/grafana/apikey")
+	data, pt.err = ioutil.ReadFile("/tmp/grafana_apikey")
 	if pt.err != nil {
 		return
 	}


### PR DESCRIPTION
* Docker build fixes
  * Got "dest dir must end with a /" error on line 3
  * Copying of Grafana key didn't work (no instructions to get the key)
* Fixed entrypoint script to get grafana api key working
  * Existing version gave:
`/performance-test/exec/performance-test-entrypoint.sh: line 18:
/performance-test/grafana/apikey: Permission denied`
  * New version uses /tmp directory
* Fixed job and pod names in tests/performance-test/deploy/README.md
  * Just a doc bug
  * Also fixed whitespace in line endings
* Added a gitignore for the hosts config
  * Removed the existing file because it gets generated at runtime