### PR TITLE
Various improvements to the perftest stuff

### DIFF
--- a/tests/performance-test/Dockerfile
+++ b/tests/performance-test/Dockerfile
@@ -18,4 +18,4 @@ RUN yum install golang -y && \
     yum clean all
 
 COPY --from=0 /tmp/main /performance-test/exec/main
-COPY deploy/scripts/unit-test.sh /performance-test/exec/unit-test.sh
+COPY deploy/scripts/launch-test.sh /performance-test/exec/launch-test.sh

--- a/tests/performance-test/README.md
+++ b/tests/performance-test/README.md
@@ -1,15 +1,16 @@
 # SAF Performance Test
 
 ## Introduction
+
 The performance test provides an automated environment in which to to run stress
-tests on the SAF locally using Minishift. Collectd-tg is used to simulate 
+tests on the SAF locally using Minishift. Collectd-tg is used to simulate
 extensive netwrok traffic to pump through SAF. Because Minishift only supports a
 single node at a time, this test demonstrates the limits of SAF in a constrained
-environment. Test scenarios are manually configured in a yaml file and results 
+environment. Test scenarios are manually configured in a yaml file and results
 can be analyzed in a series of grafana dashboards.
 
-Two additional pods are deployed by the performance test: one that hosts a 
-grafana instance and one that executes the testing logic. 
+Two additional pods are deployed by the performance test: one that hosts a
+grafana instance and one that executes the testing logic.
 
 ![A Performance Test Dashboard](images/dashboard.png)
 
@@ -30,11 +31,11 @@ Individual tests are configured in the `deploy/config/test-configs.yaml` file.
     queries:
 ```
 
-To run multiple tests in sequence, utilize the above format in additional list 
-entries within the config file. Each test generates a unique dashboard within 
+To run multiple tests in sequence, utilize the above format in additional list
+entries within the config file. Each test generates a unique dashboard within
 grafana and each query adds a new graph to its respective dashboard.
 
-# Options
+## Options
 
 Option | Description
 -------|------------
@@ -46,10 +47,11 @@ interval | collectd-tg option
 length | number of seconds the test should run, expressed as an unsigned integer
 queries | list of PromQL queries that will be graphed within the Grafana dashboard
 
-More information about collectd-tg options can be found  in the 
+More information about collectd-tg options can be found  in the
 [collectd-tg docs](https://collectd.org/documentation/manpages/collectd-tg.1.shtml)
 
-# Example Test
+## Example Test
+
 ```yaml
 - metadata:
     name: SAF Performance Test 1
@@ -63,9 +65,10 @@ More information about collectd-tg options can be found  in the
       - rate(sa_collectd_total_amqp_processed_message_count[10s])
       - sa_collectd_cpu_total
 ```
-View the [performance test deployment instructions](deploy/) to launch 
+
+View the [performance test deployment instructions](deploy/) to launch
 the performance test on Minishift.
 
 Once each test is completed, a new dashboard will be written to grafana at which
-all of the queries will be graphed. This can be seen by navigating to 
-`http://<grafana route URL>/dashboards` in a local browser. 
+all of the queries will be graphed. This can be seen by navigating to
+`http://<grafana route URL>/dashboards` in a local browser.

--- a/tests/performance-test/deploy/README.md
+++ b/tests/performance-test/deploy/README.md
@@ -23,7 +23,7 @@ More details about deploying SAF can be found in the
 [SAF deployment docs](../../../deploy/)
 
 The registry needs to be configured such that a local docker image can
-be pushed to it. To do this, a new account must be created on that has
+be pushed to it. To do this, a new openshift user must be created that has
 admin privledges. The default admin account cannot be used because it does not
 provide a token with which to login to the registry with docker.
 

--- a/tests/performance-test/deploy/README.md
+++ b/tests/performance-test/deploy/README.md
@@ -6,17 +6,19 @@ minishift v1.34.1
 docker v17.05+
 
 ### Setup
+
 SAF must already be deployed on a local minishift with the registry-route addon
 enabled. A quick way to do this is using the `quickstart.sh` script in
 `telemetry-framework/deploy/` directory to run SAF upstream version (quickstart
  can also be used to deploy the downstream):
 
 ```shell
-$ minishift addons enable registry-route   # Run BEFORE starting minishift
-$ minishift start
-$ eval $(minishift oc-env)
-$ cd $WORKDIR/telemetry-framework/deploy/; ./quickstart.sh
+minishift addons enable registry-route   # Run BEFORE starting minishift
+minishift start
+eval $(minishift oc-env)
+cd $WORKDIR/telemetry-framework/deploy/; ./quickstart.sh
 ```
+
 More details about deploying SAF on Minishift can be found in the
 [SAF deployment docs](../../../deploy/)
 
@@ -26,12 +28,13 @@ admin privledges. The default admin account cannot be used because it does not
 provide a token with which to login to the registry with docker.
 
 ```shell
-$ oc login -u developer -p passwd   # create new user if it does not already exist
-$ oc login -u system:admin
-$ oc adm policy add-cluster-role-to-user cluster-admin developer  # give user admin privlidges
-$ oc login -u developer -p passwd
-$ oc project sa-telemetry          # must use same project as SAF
+oc login -u developer -p passwd   # create new user if it does not already exist
+oc login -u system:admin
+oc adm policy add-cluster-role-to-user cluster-admin developer  # give user admin privlidges
+oc login -u developer -p passwd
+oc project sa-telemetry          # must use same project as SAF
 ```
+
 ## Build
 
 Minishift does not have an up-to-date version of docker and cannot execute
@@ -51,28 +54,28 @@ $ docker login -u developer -p $(oc whoami -t) $(minishift openshift registry) #
 
 Check that docker is using the new registry - the address should match that
 shown by `oc get routes -n default`
+
 ```shell
 $ docker info
-.
-.
+[...]
 Insecure Registries:
  docker-registry-default.192.168.42.121.nip.io
-.
-.
 ```
+
 Create and push the image to the Minishift registry
+
+```shell
+cd $WORKDIR/telemetry-framework/tests/performance-test/
+DOCKER_IMAGE="$(minishift openshift registry)/$(oc project -q)/performance-test:dev"
+docker build -t $DOCKER_IMAGE .
+docker push $DOCKER_IMAGE   #sometimes this needs to be run more than once
 ```
-$ cd $WORKDIR/telemetry-framework/tests/performance-test/
-$ DOCKER_IMAGE="$(minishift openshift registry)/$(oc project -q)/performance-test:dev"
-$ docker build -t $DOCKER_IMAGE .
-$ docker push $DOCKER_IMAGE   #sometimes this needs to be run more than once
-```
+
 Note: if an earlier version of the performance test image has been previously
 uploaded to the Minishift registry, the previous image stream and associated
 containers must be deleted before pushing up the new version else it will not
 be properly updated. Refer to the `performance-test/docker-push.sh` steps to
 do that.
-
 
 ## Deploy
 
@@ -81,9 +84,10 @@ Next, launch the grafana instance for test results gathering. This only needs
 to be done once:
 
 ```shell
-$ cd $WORKDIR/telemetry-framework/tests/performance-test/deploy
-$ ./grafana-launcher.sh
+cd $WORKDIR/telemetry-framework/tests/performance-test/deploy
+./grafana-launcher.sh
 ```
+
 The grafana launcher script will output a URL that can be used to log into the
 dashboard. This Grafana instance has all authentication disabled - if, in the
 future, the performance test should report to an authenticated grafana instance,
@@ -91,7 +95,7 @@ the test scripts must be modified. Once the Grafana instance is running, launch
 the performance test OpenShift job:
 
 ```shell
-$ ./performance-test.sh
+./performance-test.sh
 ```
 
 This will run all of the tests specified in the test-configs.yaml file in

--- a/tests/performance-test/deploy/README.md
+++ b/tests/performance-test/deploy/README.md
@@ -37,7 +37,7 @@ oc project sa-telemetry          # must use same project as SAF
 
 ## Build
 
-Openshift does not have a recent enough docker engine to execute
+OpenShift does not have a recent enough Docker engine to execute
 multistage builds. As a result, the performance test image must be built locally
 with docker v17.05 or higher and pushed to the openshift internal docker registry.
 

--- a/tests/performance-test/deploy/README.md
+++ b/tests/performance-test/deploy/README.md
@@ -2,15 +2,15 @@
 
 ## Environment
 
-minishift v1.34.1
+openshift v3.11.135
 docker v17.05+
 
 ### Setup
 
-SAF must already be deployed on a local minishift with the registry-route addon
-enabled. A quick way to do this is using the `quickstart.sh` script in
-`telemetry-framework/deploy/` directory to run SAF upstream version (quickstart
- can also be used to deploy the downstream):
+SAF must already be deployed, and your openshift must have an external route
+for the registry. A quick way to do this is using the `quickstart.sh` script in
+`telemetry-framework/deploy/` directory to run SAF. Here is an example of how
+to do that in minishift:
 
 ```shell
 minishift addons enable registry-route   # Run BEFORE starting minishift
@@ -19,11 +19,11 @@ eval $(minishift oc-env)
 cd $WORKDIR/telemetry-framework/deploy/; ./quickstart.sh
 ```
 
-More details about deploying SAF on Minishift can be found in the
+More details about deploying SAF can be found in the
 [SAF deployment docs](../../../deploy/)
 
-The Minishift registry needs to be configured such that a local docker image can
-be pushed to it. To do this, a new account must be created on Minishift that has
+The registry needs to be configured such that a local docker image can
+be pushed to it. To do this, a new account must be created on that has
 admin privledges. The default admin account cannot be used because it does not
 provide a token with which to login to the registry with docker.
 
@@ -37,19 +37,19 @@ oc project sa-telemetry          # must use same project as SAF
 
 ## Build
 
-Minishift does not have an up-to-date version of docker and cannot execute
+Openshift does not have a recent enough docker engine to execute
 multistage builds. As a result, the performance test image must be built locally
-with docker v17.05 or higher and pushed to the minshift internal docker registry.
+with docker v17.05 or higher and pushed to the openshift internal docker registry.
 
-The Minishift registry must be registered as an insecure registry for the local
+The openshift registry must be registered as an insecure registry for the local
 docker daemon to be able to push to it. On Fedora 30, this can be done like so:
 
 ```shell
-$ echo { \"insecure-registries\" : [\"$(minishift openshift registry)\"] } \
+$ echo { \"insecure-registries\" : [\"$(oc get route docker-registry -n default -o jsonpath='{.spec.host}')\"] } \
 | sudo tee  /etc/docker/daemon.json # add -a if you wish to preserve other insecure registry configurations
 $ sudo systemctl daemon-reload
 $ sudo systemctl restart docker
-$ docker login -u developer -p $(oc whoami -t) $(minishift openshift registry) # log in to registry
+$ docker login -u developer -p $(oc whoami -t) $(oc get route docker-registry -n default -o jsonpath='{.spec.host}') # log in to registry
 ```
 
 Check that docker is using the new registry - the address should match that
@@ -62,17 +62,17 @@ Insecure Registries:
  docker-registry-default.192.168.42.121.nip.io
 ```
 
-Create and push the image to the Minishift registry
+Create and push the image to the openshift registry
 
 ```shell
 cd $WORKDIR/telemetry-framework/tests/performance-test/
-DOCKER_IMAGE="$(minishift openshift registry)/$(oc project -q)/performance-test:dev"
+DOCKER_IMAGE="$(oc get route docker-registry -n default -o jsonpath='{.spec.host}')/$(oc project -q)/performance-test:dev"
 docker build -t $DOCKER_IMAGE .
 docker push $DOCKER_IMAGE   #sometimes this needs to be run more than once
 ```
 
 Note: if an earlier version of the performance test image has been previously
-uploaded to the Minishift registry, the previous image stream and associated
+uploaded to the openshift registry, the previous image stream and associated
 containers must be deleted before pushing up the new version else it will not
 be properly updated. Refer to the `performance-test/docker-push.sh` steps to
 do that.

--- a/tests/performance-test/deploy/grafana-launcher.sh
+++ b/tests/performance-test/deploy/grafana-launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Launches a grafana pod with a pre-determined graph format and exposes routes minishift
+# Launches a grafana pod with a pre-determined graph format and exposes routes
 # Important: this grafana instance is initialized with Admin permissions on the anonymous user
 # That is, authentication is disabled 
 

--- a/tests/performance-test/deploy/performance-test-job.yml
+++ b/tests/performance-test/deploy/performance-test-job.yml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: performance-test
           image: 172.30.1.1:5000/sa-telemetry/performance-test:dev
+          imagePullPolicy: Always
           command:
             - /performance-test/exec/performance-test-entrypoint.sh
           volumeMounts:

--- a/tests/performance-test/deploy/scripts/launch-test.sh
+++ b/tests/performance-test/deploy/scripts/launch-test.sh
@@ -4,7 +4,7 @@
 set -x
 ARGS=()
 
-while getopts l:n:H:p:i:d option
+while getopts l:n:H:p:i:d: option
 do
     case "${option}"
     in

--- a/tests/performance-test/deploy/scripts/launch-test.sh
+++ b/tests/performance-test/deploy/scripts/launch-test.sh
@@ -20,15 +20,15 @@ done
 
 if [ ! -v LENGTH ];
 then
-    echo "[unit-test.sh] Length of test unspecfied. Running for default time of 900s (15min)"
+    echo "[launch-test.sh] Length of test unspecfied. Running for default time of 900s (15min)"
     LENGTH=900
 fi
 
-echo "[unit-test.sh] Running collectd-tg with arguments:" "${ARGS[@]}"
+echo "[launch-test.sh] Running collectd-tg with arguments:" "${ARGS[@]}"
 collectd-tg "${ARGS[@]}" > /dev/null &
 sleep $LENGTH
 pkill collectd-tg
-echo "[unit-test.sh] Exiting test sequence"
+echo "[launch-test.sh] Exiting test sequence"
 exit
 
 

--- a/tests/performance-test/docker-push.sh
+++ b/tests/performance-test/docker-push.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-#Automates creating and pushing new performance test image to minishift registry
-
-DOCKER_IMAGE=$(minishift openshift registry)/$(oc project -q)/performance-test:dev
-
-oc delete job saf-performance-test
-oc delete is performance-test
-minishift ssh -- docker container prune -f
-IMG=$(minishift ssh -- docker images | grep performance-test | awk '{print $3}')
-minishift ssh -- docker rmi "$IMG"
+#Automates creating and pushing new performance test image to openshift registry
+PROJECT="$(oc project -q)"
+DOCKER_IMAGE="$(oc get route docker-registry -n default -o jsonpath='{.spec.host}')/${PROJECT}/performance-test:dev"
 
 docker build -t "$DOCKER_IMAGE" .
+
+oc delete is performance-test:dev
 docker push "$DOCKER_IMAGE"
 

--- a/tests/performance-test/main.go
+++ b/tests/performance-test/main.go
@@ -79,7 +79,7 @@ func (pt *PerformanceTest) ExecTest(index int) error {
 	log.Print("Running test of length " + strconv.FormatUint(test.Spec.Length, 10) + "s")
 
 	args := pt.p.ArgStrings(test)
-	out, err := exec.Command("/performance-test/exec/unit-test.sh", args...).Output()
+	out, err := exec.Command("/performance-test/exec/launch-test.sh", args...).Output()
 	if err != nil {
 		return err
 	}

--- a/tests/performance-test/main.go
+++ b/tests/performance-test/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -74,21 +76,26 @@ func (pt *PerformanceTest) InitParser() {
 
 //ExecTest runs a performance test configuration
 func (pt *PerformanceTest) ExecTest(index int) error {
-	var out []byte
 	test := pt.p.Tests()[index]
 	log.Print("Running test of length " + strconv.FormatUint(test.Spec.Length, 10) + "s")
 
 	args := pt.p.ArgStrings(test)
-	out, err := exec.Command("/performance-test/exec/launch-test.sh", args...).Output()
+	cmd := exec.Command("/performance-test/exec/launch-test.sh", args...)
+	cmd.Stderr = cmd.Stdout
+	cmdReader, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
+	cmd.Start()
 
-	for _, output := range strings.Split(string(out), "\n") {
-		if output != "" {
-			log.Print(output)
-		}
+	scanner := bufio.NewScanner(cmdReader)
+	for scanner.Scan() {
+		log.Print(scanner.Text())
 	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintln(os.Stderr, "reading standard input:", err)
+	}
+
 	log.Print("Cooling down for 30 seconds")
 	time.Sleep(time.Second * time.Duration(30))
 
@@ -104,8 +111,9 @@ func (pt *PerformanceTest) Run() {
 	for i, test := range pt.p.Tests() {
 
 		pt.start, pt.end = pt.p.GetTimes(i)
-		pt.start = pt.start.Add(time.Second * -10)
-		pt.end = pt.end.Add(time.Second * 30)
+		// BUG? These values depend on test pod startup time
+		pt.start = pt.start.Add(time.Second * -60) // Add lead time to the dashboard
+		pt.end = pt.end.Add(time.Second * 60)      // Add cool-down time to the dashboard
 
 		log.Printf("Generating dashboard '%s' from %s to %s", test.Metadata.Name, pt.start, pt.end)
 


### PR DESCRIPTION
While taking a deeper look at this and figuring out what's needed next for robust multi-cloud testing I noted a few minor annoyances (including possibly a fatal bug with the "-d" option to collectd-tg?) that I cleaned up along the way.

# Testing
I ran this and got metrics like `sa_collectd_plugin018_gauge{endpoint="prom-http",exported_instance="host0779",plugin018="ti2137288709",service="cloud1-smartgateway",type="base"}` in my prometheus.