### PR TITLE
Bump the SG version for latest errata

### DIFF
--- a/deploy/import-downstream.sh
+++ b/deploy/import-downstream.sh
@@ -27,7 +27,7 @@ oc import-image amq-interconnect-operator:latest --from=registry.redhat.io/amq7-
 
 # Currently we don't have a robust release process for the Smart Gateway or
 # corresponding Operator, so we just pull the latest version down for now.
-oc import-image smart-gateway:latest --from=registry.redhat.io/saf/smart-gateway:1.0-3 --confirm
+oc import-image smart-gateway:latest --from=registry.redhat.io/saf/smart-gateway:1.0-4 --confirm
 oc import-image smart-gateway-operator:latest --from=registry.redhat.io/saf/smart-gateway-operator:1.0.4-3 --confirm
 
 oc set image-lookup prometheus prometheus-operator prometheus-configmap-reloader prometheus-config-reloader prometheus-alertmanager amq-interconnect amq-interconnect-operator smart-gateway smart-gateway-operator


### PR DESCRIPTION
Bump the version of SG to import for downstream due to an errata being
released to account for latest CVEs in RHEL base image. No other functionality
has been changed other than bumping the base image.

https://access.redhat.com/errata/RHBA-2019:2684