### PR TITLE
Add set -e to quickstart

### DIFF
--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 #
 # Usage:
 #


### PR DESCRIPTION
Having this option would make it more obvious when something has gone wrong. @pleimer  's recent issue with not having ansible installed would now result in an immediate exit from the script with this as the last console message:
```
./quickstart.sh: line 39: ansible-playbook: command not found
```

Letting Travis test this for me.