### PR TITLE
Update to newer golang in perftest container

### DIFF
--- a/tests/performance-test/Dockerfile
+++ b/tests/performance-test/Dockerfile
@@ -1,5 +1,5 @@
 #--- Build SAF performance test ---
-FROM golang:1.12.7
+FROM golang:1.13
 WORKDIR /go/src/performance-test/
 
 COPY ./dashboard.go ./main.go ./parser.go ./


### PR DESCRIPTION
https://github.com/grafana-tools/sdk/pull/38/files says we need 1.13