### PR TITLE
Fix perftest build

### DIFF
--- a/tests/performance-test/dashboard.go
+++ b/tests/performance-test/dashboard.go
@@ -118,10 +118,10 @@ func (d *Dashboard) Update() error {
 		if err != nil {
 			return err
 		}
-		err = d.client.SetDashboard(*d.board, false)
+		_, err = d.client.SetDashboard(*d.board, false)
 	} else {
 		log.Print("Creating new dashboard")
-		err = d.client.SetDashboard(*d.board, false)
+		_, err = d.client.SetDashboard(*d.board, false)
 	}
 	return err
 }


### PR DESCRIPTION
Before this fix (during docker build):
```
# performance-test
./dashboard.go:121:7: assignment mismatch: 1 variable but d.client.SetDashboard returns 2 values
./dashboard.go:124:7: assignment mismatch: 1 variable but d.client.SetDashboard returns 2 values
The command '/bin/sh -c go get gopkg.in/yaml.v2 &&     go get github.com/grafana-tools/sdk &&     go build -o main &&     mv main /tmp/' returned a non-zero code: 2
```

Cause is this upstream change: https://github.com/grafana-tools/sdk/pull/33/files#diff-360b9f3ea407e904e28272cb297b43dbR159

After this fix, the golang part of the build succeeds. 

I didn't test any deeper than that (or add proper error handling that outputs the new StatusMessage return value) because I want to throw this code away anyways.

I've actually not been able to fully verify this due to a package problem in the second stage - reverting this change didn't fix it, so it's independent.

```
Step 7/9 : RUN yum install golang -y &&     yum update -y &&     yum clean all
 ---> Running in a8dc00a5d6a8

--> Finished Dependency Resolution
Error: Package: collectd-rdt-5.8.1-4.el7.x86_64 (@centos-release-opstools)
           Requires: libpqos-1.0.1.so()(64bit)
           Removing: intel-cmt-cat-1.0.1-1.el7.x86_64 (@centos-release-opstools)
               libpqos-1.0.1.so()(64bit)
           Updated By: intel-cmt-cat-3.0.1-1.el7.x86_64 (base)
               Not found
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
The command '/bin/sh -c yum install golang -y &&     yum update -y &&     yum clean all' returned a non-zero code: 1
```