### PR TITLE
Pull performance test image from quay.io instead of from internal registry

### DIFF
--- a/tests/performance-test/deploy/performance-test-job-tg.yml.template
+++ b/tests/performance-test/deploy/performance-test-job-tg.yml.template
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: performance-test
-          image: <<REGISTRY_INFO>>/sa-telemetry/performance-test:dev
+          image: quay.io/plmr/performance-test:dev
           imagePullPolicy: Always
           command:
             - /performance-test/exec/performance-test-entrypoint.sh


### PR DESCRIPTION
This removes many of the steps required for building the docker image in the performance test by telling the job to pull a static image in Quay.io. We were having a lot of issues building the images locally and this will allow development to continue without the problems of building every time. This is a temporary solution, but necessary for now