### PR TITLE
Small change to quickstart to make it work outside of minishift

### DIFF
--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -9,7 +9,7 @@ set -e
 oc login -u system:admin
 oc new-project sa-telemetry
 
-# make sure thre is a node that matches ElasticSearch's node selector
+# make sure there is a node that matches ElasticSearch's node selector
 oc patch node $(oc get node | tail -1 | awk '{print $1}') -p '{"metadata":{"labels":{"kubernetes.io/os": "linux"}}}'
 
 # generate certificates for AMQ Interconnect

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -9,8 +9,8 @@ set -e
 oc login -u system:admin
 oc new-project sa-telemetry
 
-# make sure ElasticSearch is scheduled on a node
-oc patch node localhost -p '{"metadata":{"labels":{"kubernetes.io/os": "linux"}}}'
+# make sure thre is a node that matches ElasticSearch's node selector
+oc patch node $(oc get node | tail -1 | awk '{print $1}') -p '{"metadata":{"labels":{"kubernetes.io/os": "linux"}}}'
 
 # generate certificates for AMQ Interconnect
 openssl req -new -x509 -batch -nodes -days 11000 \


### PR DESCRIPTION
Reminder that quickstart.sh is not for production use. I don't recommend this approach in general. :)

Still looking for an environment-agnostic way to get the `sysctl` command executed on the labelled node, but that's not for this PR.