### PR TITLE
Add events testing to smoke test

### DIFF
--- a/tests/smoketest/minimal-collectd.conf.template
+++ b/tests/smoketest/minimal-collectd.conf.template
@@ -8,9 +8,7 @@ LoadPlugin "logfile"
 </Plugin>
 
 LoadPlugin cpu
-LoadPlugin interface
 LoadPlugin amqp1
-
 <Plugin "amqp1">
   <Transport "name">
     Host "qdr-white.sa-telemetry.svc.cluster.local"
@@ -28,11 +26,13 @@ LoadPlugin amqp1
   </Transport>
 </Plugin>
 
+LoadPlugin interface
 <Plugin interface>
   IgnoreSelected true
   ReportInactive true
 </Plugin>
 
+LoadPlugin threshold
 <Plugin threshold>
   <Plugin "interface">
     Instance "lo"

--- a/tests/smoketest/smoketest_entrypoint.sh
+++ b/tests/smoketest/smoketest_entrypoint.sh
@@ -39,7 +39,7 @@ curl -g "${PROMETHEUS}/api/v1/query?" --data-urlencode 'query=sa_collectd_cpu_to
 echo; echo
 
 # The egrep exit code is the result of the test and becomes the container/pod/job exit code
-egrep '"result":\[{"metric":{"__name__":"sa_collectd_cpu_total","cpu":"0","endpoint":"prom-http","exported_instance":"'"${POD}"'","service":"'"${CLOUDNAME}"'-telemetry-smartgateway","type":"user"},"values":\[\[.+,".+"\]' /tmp/query_output
+grep -E '"result":\[{"metric":{"__name__":"sa_collectd_cpu_total","cpu":"0","endpoint":"prom-http","exported_instance":"'"${POD}"'","service":"'"${CLOUDNAME}"'-telemetry-smartgateway","type":"user"},"values":\[\[.+,".+"\]' /tmp/query_output
 metrics_result=$?
 
 echo "Get documents for this test from ElasticSearch..."
@@ -50,7 +50,7 @@ DOCUMENT_HITS=$(curl -sk --cacert /certificates/admin-ca --cert /certificates/ad
   "query": {
     "match_phrase": {
       "labels.instance": {
-        "query": "saf-smoketest-'${CLOUDNAME}'*"
+        "query": "saf-smoketest-'"${CLOUDNAME}"'*"
       }
     }
   }
@@ -59,11 +59,11 @@ echo; echo
 
 # check if we got documents back for this test
 events_result=1
-if [ $DOCUMENT_HITS > 0 ]; then
+if [ "$DOCUMENT_HITS" -gt "0" ]; then
     events_result=0
 fi
 
-if [[ $metrics_result == 0 && $events_result == 0 ]]; then
+if [ "$metrics_result" = "0" ] && [ "$events_result" = "0" ]; then
     exit 0
 else
     exit 1

--- a/tests/smoketest/smoketest_entrypoint.sh
+++ b/tests/smoketest/smoketest_entrypoint.sh
@@ -48,9 +48,21 @@ DOCUMENT_HITS=$(curl -sk --cacert /certificates/admin-ca --cert /certificates/ad
   "size": 0,
   "terminate_after": 1,
   "query": {
-    "match_phrase": {
-      "labels.instance": {
-        "query": "saf-smoketest-'"${CLOUDNAME}"'*"
+    "bool": {
+      "must": {
+        "match_phrase": {
+          "labels.instance": {
+            "query": "saf-smoketest-'"${CLOUDNAME}"'*"
+          }
+        }
+      },
+      "filter": {
+        "range" : {
+          "startsAt" : {
+            "gte" : "now-1m",
+            "lt" :  "now"
+           }
+         }
       }
     }
   }

--- a/tests/smoketest/smoketest_entrypoint.sh
+++ b/tests/smoketest/smoketest_entrypoint.sh
@@ -29,10 +29,6 @@ done
 # Sleeping to collect 1m of actual metrics
 sleep 60
 
-echo "Get indices from ElasticSearch..."
-curl -k --cacert /certificates/admin-ca --cert /certificates/admin-cert --key /certificates/admin-key "https://${ELASTICSEARCH}/_cat/indices?v" | tee /tmp/index_results
-echo; echo
-
 echo "List of metric names for debugging..."
 curl -g "${PROMETHEUS}/api/v1/label/__name__/values" 2>&2 | tee /tmp/label_names
 echo; echo
@@ -46,6 +42,29 @@ echo; echo
 egrep '"result":\[{"metric":{"__name__":"sa_collectd_cpu_total","cpu":"0","endpoint":"prom-http","exported_instance":"'"${POD}"'","service":"'"${CLOUDNAME}"'-telemetry-smartgateway","type":"user"},"values":\[\[.+,".+"\]' /tmp/query_output
 metrics_result=$?
 
-# add events results
+echo "Get documents for this test from ElasticSearch..."
+DOCUMENT_HITS=$(curl -sk --cacert /certificates/admin-ca --cert /certificates/admin-cert --key /certificates/admin-key -X GET "https://${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'
+{
+  "size": 0,
+  "terminate_after": 1,
+  "query": {
+    "match_phrase": {
+      "labels.instance": {
+        "query": "saf-smoketest-'${CLOUDNAME}'*"
+      }
+    }
+  }
+}' | python -c "import sys, json; print json.load(sys.stdin)['hits']['total']")
+echo; echo
 
-exit $metrics_result
+# check if we got documents back for this test
+events_result=1
+if [ $DOCUMENT_HITS > 0 ]; then
+    events_result=0
+fi
+
+if [[ $metrics_result == 0 && $events_result == 0 ]]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
Add functionality to the smoketest_entrypoint.sh that will return the number of
documents created during the test. Testing will return only true if both the
events and metrics smoke tests return without issue.

Updates the collectd minimal configuration for smoke testing to load the
appropriate plugins so that the threshold plugin will result in a bunch of
events being written into an index within ElasticSearch.