### PR TITLE
Configured edge router to accept connection from telemetry bench and …

### DIFF
--- a/tests/performance-test/deploy/performance-test-job-tb.yml.template
+++ b/tests/performance-test/deploy/performance-test-job-tb.yml.template
@@ -17,7 +17,7 @@ spec:
         - name: performance-test
           image: quay.io/redhat-service-assurance/telemetry-bench
           imagePullPolicy: Always
-          args: ["-hostprefix", "<<PREFIX>>", "-hosts", "<<HOSTS>>", "-plugins", "<<PLUGINS>>", "-instances", "1", "-send", "<<COUNT>>", "-interval", "<<INTERVAL>>", "-startmetricenable", "-verbose", "amqp://qdr-white.sa-telemetry.svc.cluster.local:5672/collectd/telemetry/"]
+          args: ["-hostprefix", "<<PREFIX>>", "-hosts", "<<HOSTS>>", "-plugins", "<<PLUGINS>>", "-instances", "1", "-send", "<<COUNT>>", "-interval", "<<INTERVAL>>", "-startmetricenable", "-verbose", "amqp://qdr-test.sa-telemetry.svc.cluster.local:5672/collectd/telemetry/"]
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/tests/performance-test/deploy/qdrouterd.yaml
+++ b/tests/performance-test/deploy/qdrouterd.yaml
@@ -20,7 +20,7 @@ spec:
       distribution: closest
     - prefix: broadcast
       distribution: multicast
-    - prefix: collectd
+    - prefix: collectd/telemetry
       distribution: multicast
     - prefix: collectd/notify
       distribution: multicast

--- a/tests/performance-test/deploy/qdrouterd.yaml
+++ b/tests/performance-test/deploy/qdrouterd.yaml
@@ -1,0 +1,42 @@
+apiVersion: interconnectedcloud.github.io/v1alpha1
+kind: Qdr
+metadata:
+  name: qdr-test
+  namespace: sa-telemetry
+spec:
+  deploymentPlan:
+      image: docker-registry.default.svc:5000/sa-telemetry/amq-interconnect:1.4-7
+      role: edge
+      size: 1
+      placement: Any
+  addresses:
+    - prefix: closest
+      distribution: closest
+    - prefix: multicast
+      distribution: multicast
+    - prefix: unicast
+      distribution: closest
+    - prefix: exclusive
+      distribution: closest
+    - prefix: broadcast
+      distribution: multicast
+    - prefix: collectd
+      distribution: multicast
+    - prefix: collectd/notify
+      distribution: multicast
+  sslProfiles:
+    - name: default
+      credentials: "qdr-white-cert"
+  edgeListeners:
+    - host: "0.0.0.0"
+      port: 5671
+      expose: true
+  listeners:
+    - port: 5672
+    - port: 8672
+      http: true
+  edgeConnectors:
+    - name: router
+      host: qdr-white.sa-telemetry.svc.cluster.local
+      port: 5671
+      verifyHostname: no

--- a/tests/performance-test/deploy/qdrouterd.yaml
+++ b/tests/performance-test/deploy/qdrouterd.yaml
@@ -24,9 +24,6 @@ spec:
       distribution: multicast
     - prefix: collectd/notify
       distribution: multicast
-  sslProfiles:
-    - name: default
-      credentials: "qdr-white-cert"
   edgeListeners:
     - host: "0.0.0.0"
       port: 5671

--- a/tests/performance-test/performance-test.sh
+++ b/tests/performance-test/performance-test.sh
@@ -35,40 +35,41 @@ ENDUSAGE
     exit 1
 }
 
-ELIPSE="."
-elipses(){
-    case $ELIPSE in
-    ".") printf "%s" $ELIPSE
-         ELIPSE=".."
+# Ellipse - update an ellipse string everytime called. Conveys loading, waiting, etc
+ELLIPSE=".  "
+ellipse(){
+    case $ELLIPSE in
+    ".  ") printf "%s" "$ELLIPSE"
+         ELLIPSE=".. "
     ;;
-    "..") printf "%s" $ELIPSE
-          ELIPSE="..."
+    ".. ") printf "%s" "$ELLIPSE"
+          ELLIPSE="..."
     ;;
-    "...") printf "%s" $ELIPSE
-           ELIPSE="."
+    "...") printf "%s" "$ELLIPSE"
+           ELLIPSE=".  "
     ;;
     esac
 }
 
-create_grafana_datasources(){
+make_grafana_datasources(){
     echo "Creating OCP datasource"
     RESP=$(curl --silent --output /dev/null -d "$OCP_DATASOURCE" -H 'Content-Type: application/json' "$GRAF_HOST/api/datasources")
-    if [ ! -z "$(echo $RESP | grep "RequiredError")" ]; then
+    if echo "$RESP" | grep -q "RequiredError"; then
         echo "Unable to create OCP datasource with reply: "
-        echo $RESP
+        echo "$RESP"
         exit 1
     fi
 
     echo "Creating SAF datasource"
     RESP=$(curl --silent --output /dev/null -d "$SAF_DATASOURCE" -H 'Content-Type: application/json' "$GRAF_HOST/api/datasources")
-    if [ ! -z "$(echo $RESP | grep "RequiredError")" ]; then
+    if echo "$RESP" | grep -q "RequiredError"; then
         echo "Unable to create SAF datasource with reply: "
-        echo $RESP
+        echo "$RESP"
         exit 1
     fi
 }
 
-create_service_monitors(){
+make_service_monitors(){
     oc apply -f ./grafana/prom-servicemonitor.yml 
     oc apply -f ./grafana/qdr-servicemonitor.yml
 }
@@ -92,10 +93,10 @@ get_sources(){
     OCP_PROM_HOST="https:\/\/$(oc get routes --field-selector metadata.name=prometheus-k8s -o jsonpath="{.items[0].spec.host}")"
     OCP_DATASOURCE=$(oc get secret -n openshift-monitoring grafana-datasources -o jsonpath='{.data.prometheus\.yaml}' \
         | base64 -d)
-    OCP_DATASOURCE=$(echo $OCP_DATASOURCE | sed 's/.*\[\([^]]*\)\].*/\1/g') #get DS json from between brackets
-    OCP_DATASOURCE=$(echo $OCP_DATASOURCE | sed 's/"name": "[a-z]*"/"name": "OCPPrometheus"/g')  #Change DS name
-    OCP_DATASOURCE=$(echo $OCP_DATASOURCE | sed 's/"url": "[^,]*"/"url": "PROMHOST"/g')     #DS placeholder url
-    OCP_DATASOURCE=$(echo $OCP_DATASOURCE | sed "s/\"url\": \"PROMHOST\"/\"url\": \"${OCP_PROM_HOST}\"/g") #Change DS url
+    OCP_DATASOURCE=$(echo "$OCP_DATASOURCE" | sed 's/.*\[\([^]]*\)\].*/\1/g') #get DS json from between brackets
+    OCP_DATASOURCE=$(echo "$OCP_DATASOURCE" | sed 's/"name": "[a-z]*"/"name": "OCPPrometheus"/g')  #Change DS name
+    OCP_DATASOURCE=$(echo "$OCP_DATASOURCE" | sed 's/"url": "[^,]*"/"url": "PROMHOST"/g')     #DS placeholder url
+    OCP_DATASOURCE=$(echo "$OCP_DATASOURCE" | sed "s/\"url\": \"PROMHOST\"/\"url\": \"${OCP_PROM_HOST}\"/g") #Change DS url
 
     if ! oc project sa-telemetry; then 
         echo "Error: SAF does not exist on cluster. Deploy SAF before running performance test" 1>&2
@@ -158,20 +159,21 @@ else
 fi
 
 get_sources
-create_grafana_datasources
-create_service_monitors
+make_grafana_datasources
+make_service_monitors
 post_dashboards
 
 STAGE="TARGET"
 while true; do
     case $STAGE in
         "TARGET")
-            TARGETS=`curl "http://$(oc get route prometheus -o jsonpath='{.spec.host}')/api/v1/targets"`
-            QDR=`echo $TARGETS | grep -o '"__meta_kubernetes_service_name":"qdr-white"'`
-            PROM=`echo $TARGETS | grep -o '"__meta_kubernetes_service_name":"prometheus-operated"'`
+            TARGETS=$(curl "http://$(oc get route prometheus -o jsonpath='{.spec.host}')/api/v1/targets")
+            QDR=$(echo "$TARGETS" | grep -o '"__meta_kubernetes_service_name":"qdr-white"')
+            PROM=$(echo "$TARGETS" | grep -o '"__meta_kubernetes_service_name":"prometheus-operated"')
 
             if [ -z "$QDR" ] && [ -z "$PROM" ]; then
-                echo "Waiting for new targets to be recognized by Prometheus Operator"
+                printf "%s" "Waiting for new targets to be recognized by Prometheus Operator"; ellipse
+                printf "\r"
                 sleep 10
             else
                 echo "Found new target endpoints"
@@ -182,7 +184,7 @@ while true; do
             make_qdr_edge_router
             estab=$(oc get pod -l qdr_cr=qdr-test -o jsonpath='{.items[0].status.conditions[?(@.type=="ContainersReady")].status}') || true
             if [ "${estab}" != "True" ]; then
-                printf "%s" "Waiting on qdr edge test pod creation"; elipses
+                printf "%s" "Waiting on qdr edge test pod creation"; ellipse
                 printf "\r"
                 sleep 1
             else
@@ -193,10 +195,10 @@ while true; do
                 STAGE="TEST"
             fi
         ;;
-        "TEST") 
+        "TEST")
             estab=$(oc get pod -l job-name=saf-perftest-1-runner -o jsonpath='{.items[0].status.conditions[?(@.type=="ContainersReady")].status}') || true
             if [ "${estab}" != "True" ]; then
-                printf '%s' "Waiting on SAF performance test pod creation"; elipses
+                printf '%s' "Waiting on SAF performance test pod creation"; ellipse
                 printf "\r"
                 sleep 1
             else
@@ -211,7 +213,7 @@ while true; do
     esac
 done
 
-oc logs -f $(oc get pod -l job-name=saf-perftest-1-runner -o jsonpath='{.items[0].metadata.name}') |  grep -E 'total [0-9]+'
+oc logs -f "$(oc get pod -l job-name=saf-perftest-1-runner -o jsonpath='{.items[0].metadata.name}')" |  grep -E 'total [0-9]+'
 echo "Test complete"
 
 


### PR DESCRIPTION
In order to more realisticly test SAF, the setup needed to more closely reflect a real life setup in which data would come into an edge router on the client side before being routed over to the amq bus in SAF: tool -> qdr -> qdr -> sg.

I have added in a new router to satisfy this condition. The performance test automatically deploys and tracks the new router and points telemetry bench to send metrics through it. 