### PR TITLE
Simplified collectd prefix in qdr config

### DIFF
--- a/tests/performance-test/deploy/qdrouterd.yaml
+++ b/tests/performance-test/deploy/qdrouterd.yaml
@@ -20,9 +20,7 @@ spec:
       distribution: closest
     - prefix: broadcast
       distribution: multicast
-    - prefix: collectd/telemetry
-      distribution: multicast
-    - prefix: collectd/notify
+    - prefix: collectd
       distribution: multicast
   edgeListeners:
     - host: "0.0.0.0"


### PR DESCRIPTION
Paul had this right initially in the PR. This shorter prefix is simpler, more flexible, and more closely matches what the client side uses for real. See: https://github.com/openstack/tripleo-heat-templates/commit/13ffaf688ecabb02378e8ef31107ae2be7fd1010