### PR TITLE
Templated qdr registry URL in perftest

### DIFF
--- a/tests/performance-test/deploy/qdrouterd.yaml.template
+++ b/tests/performance-test/deploy/qdrouterd.yaml.template
@@ -5,7 +5,7 @@ metadata:
   namespace: sa-telemetry
 spec:
   deploymentPlan:
-      image: docker-registry.default.svc:5000/sa-telemetry/amq-interconnect:1.4-7
+      image: <<REGISTRY_INFO>>/sa-telemetry/amq-interconnect:1.4-7
       role: edge
       size: 1
       placement: Any

--- a/tests/performance-test/performance-test.sh
+++ b/tests/performance-test/performance-test.sh
@@ -77,7 +77,7 @@ make_service_monitors(){
 make_qdr_edge_router(){
     if ! oc get qdr qdr-test; then
         echo "Deploying edge router"
-        oc create -f ./deploy/qdrouterd.yaml
+        oc create -f <(sed -e "s/<<REGISTRY_INFO>>/$(oc registry info)/" ./deploy/qdrouterd.yaml.template)
         return
     fi
     echo "Utilizing existing edge router"


### PR DESCRIPTION
Perftest script isn't working for me; noticed this image pull problem in my minishift environment where `docker-registry.default.svc` doesn't work so templated it like various other places we refer to the registry.

I'm l running into a problem with the OCPPrometheus datasource, so the perftest stuff is still broken for me, but this definitely helps.