### PR TITLE
Fix perftest QDR not deploying

### DIFF
--- a/tests/performance-test/performance-test.sh
+++ b/tests/performance-test/performance-test.sh
@@ -61,8 +61,7 @@ make_service_monitors(){
 make_qdr_edge_router(){
     if ! oc get qdr qdr-test; then
         printf "\n*** Deploying Edge Router ***\n"
-        sed -e "s/<<REGISTRY_INFO>>/$(oc registry info)/g" ./deploy/qdrouterd.yaml > /tmp/qdr-test.yaml
-        oc create -f /tmp/qdr-test.yaml
+        oc create -f <(sed -e "s/<<REGISTRY_INFO>>/$(oc registry info)/g" ./deploy/qdrouterd.yaml.template)
         return
     fi
     echo "Utilizing existing edge router"


### PR DESCRIPTION
$   ./performance-test.sh -t tb -c 600 -h 5 -p 1000 -i 1 -n 4
[...]
*** Deploying Edge Router ***
sed: can't read ./deploy/qdrouterd.yaml: No such file or directory

*  Code could never have worked, filename is wrong

Still having trouble with the dashboards not loading, but this got me past the QDR hurdle.