### PR TITLE
Set telemetry-bench to send unsettled messages in Perf Test

### DIFF
--- a/tests/performance-test/deploy/entrypoint.sh
+++ b/tests/performance-test/deploy/entrypoint.sh
@@ -2,4 +2,4 @@
 
 /usr/sbin/collectd -C /tmp/minimal-collectd.conf -f 2>&1 | tee /tmp/collectd_output
 
-sleep 5
+sleep 10

--- a/tests/performance-test/deploy/performance-test-job-tb.yml.template
+++ b/tests/performance-test/deploy/performance-test-job-tb.yml.template
@@ -17,7 +17,7 @@ spec:
         - name: performance-test
           image: quay.io/redhat-service-assurance/telemetry-bench
           imagePullPolicy: Always
-          args: ["-hostprefix", "<<PREFIX>>", "-hosts", "<<HOSTS>>", "-plugins", "<<PLUGINS>>", "-instances", "1", "-send", "<<COUNT>>", "-interval", "<<INTERVAL>>", "-startmetricenable", "-verbose", "amqp://qdr-test.sa-telemetry.svc.cluster.local:5672/collectd/telemetry/"]
+          args: ["-hostprefix", "<<PREFIX>>", "-hosts", "<<HOSTS>>", "-plugins", "<<PLUGINS>>", "-instances", "1", "-send", "<<COUNT>>", "-interval", "<<INTERVAL>>", "-startmetricenable", "-verbose", "-ack","amqp://qdr-test.sa-telemetry.svc.cluster.local:5672/collectd/telemetry/"]
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
After some investigation as to why the QDR->QDR setup in the Performance Test was causing messages to be dropped by qdr, I set telemetry bench to send unsettled messages as opposed to pre-settled. After some testing, this seems to have solved the issue.

With pre-settled messages: 

![image](https://user-images.githubusercontent.com/41337120/68598864-94a4dc00-046d-11ea-9e9d-984a1d5c235c.png)

With unsettled messages:

![image](https://user-images.githubusercontent.com/41337120/68598889-9e2e4400-046d-11ea-937a-0f444a6945d0.png)
