### PR TITLE
Visual tweaks to perftest dashboard

### DIFF
--- a/tests/performance-test/grafana/perftest-dashboard.json
+++ b/tests/performance-test/grafana/perftest-dashboard.json
@@ -19,83 +19,123 @@
   "links": [],
   "panels": [
     {
-      "datasource": "SAFElasticsearch",
-      "description": "Describes the ratio of number of events triggered in the cloud to the number of events logged in Elastic Search.  \n\nThis result WILL NOT be accurate until after a performance test has completed. Result reflects the most recent test only - resizing the dashboard time interval over previous tests will not give the correct result for that previous test.",
+      "collapsed": false,
+      "datasource": null,
       "gridPos": {
-        "h": 7,
-        "w": 12,
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 72,
-      "options": {
-        "fieldOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "defaults": {
-            "links": [
-              {
-                "title": "",
-                "url": ""
-              }
-            ],
-            "mappings": [],
-            "max": 1,
-            "min": 0,
-            "thresholds": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 0.97
-              }
-            ],
-            "unit": "percentunit"
-          },
-          "override": {},
-          "values": false
-        },
-        "orientation": "auto",
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
+      "id": 43,
+      "panels": [],
+      "title": "Test Indicators",
+      "type": "row"
+    },
+    {
+      "dashboardFilter": "",
+      "dashboardTags": [],
+      "datasource": "OCPPrometheus",
+      "folderId": null,
+      "gridPos": {
+        "h": 10,
+        "w": 4,
+        "x": 0,
+        "y": 1
       },
-      "pluginVersion": "6.4.3",
+      "id": 36,
+      "limit": 10,
+      "nameFilter": "",
+      "onlyAlertsOnDashboard": false,
+      "options": {},
+      "show": "current",
+      "sortOrder": 1,
+      "stateFilter": [],
       "targets": [
         {
-          "bucketAggs": [
-            {
-              "field": "startsAt",
-              "id": "2",
-              "settings": {
-                "interval": "auto",
-                "min_doc_count": 0,
-                "trimEdges": 0
-              },
-              "type": "date_histogram"
-            }
-          ],
-          "metrics": [
-            {
-              "field": "events_successful",
-              "id": "1",
-              "meta": {},
-              "settings": {},
-              "type": "avg"
-            }
-          ],
-          "query": "_type:status",
-          "refId": "A",
-          "timeField": "startsAt"
+          "expr": "kube_node_status_condition",
+          "hide": false,
+          "refId": "A"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Event Success Rate",
-      "transparent": true,
-      "type": "gauge"
+      "title": "Testing Alerts",
+      "type": "alertlist"
+    },
+    {
+      "columns": [],
+      "datasource": "OCPPrometheus",
+      "description": "Entries will appear here for nodes that report Unready,  Disk/Memory/PID Pressure, or that return \"Unknown\" for any of those statuses.",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 4,
+        "y": 1
+      },
+      "id": 38,
+      "options": {},
+      "pageSize": 10,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "",
+          "colorMode": "row",
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [
+            "1",
+            "1"
+          ],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "label_replace(max(kube_node_status_condition{node=~\".*node-.*\", status=\"unknown\"}) by (node, condition) > 0, \"short_node\", \"$1\", \"node\", '([^.]+).*')",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{short_node}} | {{condition}} (UNKNOWN)",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(max(kube_node_status_condition{node=~\".*node-.*\", status=\"true\", condition!=\"Ready\"}) by (node, condition) > 0, \"short_node\", \"$1\", \"node\", '([^.]+).*')",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{short_node}} | {{condition}}",
+          "refId": "B"
+        },
+        {
+          "expr": "label_replace(min(kube_node_status_condition{node=~\".*node-.*\", status=\"false\", condition=\"Ready\"}) by (node) > 0, \"short_node\", \"$1\", \"node\", '([^.]+).*')",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{short_node}} | UnReady",
+          "refId": "C"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Node Status Faults",
+      "transform": "timeseries_to_rows",
+      "type": "table"
     },
     {
       "cacheTimeout": null,
@@ -122,7 +162,7 @@
         "h": 3,
         "w": 3,
         "x": 12,
-        "y": 0
+        "y": 1
       },
       "id": 64,
       "interval": null,
@@ -206,7 +246,7 @@
         "h": 3,
         "w": 3,
         "x": 15,
-        "y": 0
+        "y": 1
       },
       "id": 66,
       "interval": null,
@@ -275,7 +315,7 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 0
+        "y": 1
       },
       "id": 68,
       "options": {
@@ -312,7 +352,7 @@
         "showThresholdLabels": true,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.4.3",
+      "pluginVersion": "6.4.4",
       "targets": [
         {
           "expr": "sum(count_over_time({exported_instance !~ \"saf-performance-test.*\", type =~ \".+\"}[$__range])) / vector(scalar(delta(deliveries_ingress[$__range])))",
@@ -323,8 +363,32 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "% of msgs QDR -> Prom",
+      "title": "% of metrics QDR -> Prom",
       "type": "gauge"
+    },
+    {
+      "dashboardFilter": "",
+      "dashboardTags": [],
+      "datasource": null,
+      "folderId": null,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 4,
+        "y": 4
+      },
+      "id": 54,
+      "limit": "10000",
+      "nameFilter": "",
+      "onlyAlertsOnDashboard": true,
+      "options": {},
+      "show": "changes",
+      "sortOrder": 1,
+      "stateFilter": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Alert History",
+      "type": "alertlist"
     },
     {
       "cacheTimeout": null,
@@ -349,7 +413,7 @@
         "h": 3,
         "w": 3,
         "x": 12,
-        "y": 3
+        "y": 4
       },
       "id": 52,
       "interval": null,
@@ -411,6 +475,85 @@
       "valueName": "delta"
     },
     {
+      "datasource": "SAFElasticsearch",
+      "description": "Describes the ratio of number of events triggered in the cloud to the number of events logged in Elastic Search.  \n\nThis result WILL NOT be accurate until after a performance test has completed. Result reflects the most recent test only - resizing the dashboard time interval over previous tests will not give the correct result for that previous test.",
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 15,
+        "y": 4
+      },
+      "id": 72,
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "defaults": {
+            "links": [
+              {
+                "title": "",
+                "url": ""
+              }
+            ],
+            "mappings": [],
+            "max": 1,
+            "min": 0,
+            "thresholds": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.97
+              }
+            ],
+            "unit": "percentunit"
+          },
+          "override": {},
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.4.4",
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "startsAt",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "events_successful",
+              "id": "1",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "query": "_type:status",
+          "refId": "A",
+          "timeField": "startsAt"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Event Success Rate",
+      "transparent": true,
+      "type": "gauge"
+    },
+    {
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
@@ -433,7 +576,7 @@
         "h": 3,
         "w": 3,
         "x": 12,
-        "y": 6
+        "y": 7
       },
       "id": 48,
       "interval": null,
@@ -517,7 +660,7 @@
         "h": 3,
         "w": 3,
         "x": 18,
-        "y": 6
+        "y": 7
       },
       "id": 70,
       "interval": null,
@@ -602,7 +745,7 @@
         "h": 3,
         "w": 3,
         "x": 21,
-        "y": 6
+        "y": 7
       },
       "id": 26,
       "interval": null,
@@ -669,156 +812,13 @@
       "valueName": "min"
     },
     {
-      "dashboardFilter": "",
-      "dashboardTags": [],
-      "datasource": "OCPPrometheus",
-      "folderId": null,
-      "gridPos": {
-        "h": 10,
-        "w": 4,
-        "x": 0,
-        "y": 7
-      },
-      "id": 36,
-      "limit": 10,
-      "nameFilter": "",
-      "onlyAlertsOnDashboard": false,
-      "options": {},
-      "show": "current",
-      "sortOrder": 1,
-      "stateFilter": [],
-      "targets": [
-        {
-          "expr": "kube_node_status_condition",
-          "hide": false,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Testing Alerts",
-      "type": "alertlist"
-    },
-    {
-      "columns": [],
-      "datasource": "OCPPrometheus",
-      "description": "Entries will appear here for nodes that report Unready,  Disk/Memory/PID Pressure, or that return \"Unknown\" for any of those statuses.",
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 4,
-        "y": 7
-      },
-      "id": 38,
-      "options": {},
-      "pageSize": 10,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "colorMode": "row",
-          "colors": [
-            "rgba(50, 172, 45, 0.97)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(245, 54, 54, 0.9)"
-          ],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [
-            "1",
-            "1"
-          ],
-          "type": "number",
-          "unit": "short"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "label_replace(max(kube_node_status_condition{node=~\".*node-.*\", status=\"unknown\"}) by (node, condition) > 0, \"short_node\", \"$1\", \"node\", '([^.]+).*')",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{short_node}} | {{condition}} (UNKNOWN)",
-          "refId": "A"
-        },
-        {
-          "expr": "label_replace(max(kube_node_status_condition{node=~\".*node-.*\", status=\"true\", condition!=\"Ready\"}) by (node, condition) > 0, \"short_node\", \"$1\", \"node\", '([^.]+).*')",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{short_node}} | {{condition}}",
-          "refId": "B"
-        },
-        {
-          "expr": "label_replace(min(kube_node_status_condition{node=~\".*node-.*\", status=\"false\", condition=\"Ready\"}) by (node) > 0, \"short_node\", \"$1\", \"node\", '([^.]+).*')",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{short_node}} | UnReady",
-          "refId": "C"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Node Status Faults",
-      "transform": "timeseries_to_rows",
-      "type": "table"
-    },
-    {
-      "dashboardFilter": "",
-      "dashboardTags": [],
-      "datasource": null,
-      "folderId": null,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 4,
-        "y": 10
-      },
-      "id": 54,
-      "limit": "10000",
-      "nameFilter": "",
-      "onlyAlertsOnDashboard": true,
-      "options": {},
-      "show": "changes",
-      "sortOrder": 1,
-      "stateFilter": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Alert History",
-      "type": "alertlist"
-    },
-    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
-      },
-      "id": 43,
-      "panels": [],
-      "title": "Test Indicators",
-      "type": "row"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 18
+        "y": 11
       },
       "id": 56,
       "panels": [],
@@ -895,7 +895,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 12
       },
       "id": 60,
       "legend": {
@@ -1002,7 +1002,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 12
       },
       "id": 58,
       "legend": {
@@ -1084,7 +1084,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 20
       },
       "id": 28,
       "panels": [],
@@ -1162,7 +1162,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 21
       },
       "id": 24,
       "legend": {
@@ -1312,7 +1312,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 21
       },
       "id": 32,
       "legend": {
@@ -1410,7 +1410,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 28
       },
       "id": 15,
       "panels": [],
@@ -1464,7 +1464,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 29
       },
       "id": 13,
       "legend": {
@@ -1603,7 +1603,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 29
       },
       "id": 30,
       "legend": {
@@ -1705,7 +1705,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 36
       },
       "id": 11,
       "legend": {
@@ -1843,7 +1843,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 43
+        "y": 36
       },
       "id": 21,
       "legend": {
@@ -1946,7 +1946,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 43
+        "y": 36
       },
       "id": 46,
       "legend": {
@@ -2027,7 +2027,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 43
       },
       "id": 17,
       "panels": [],
@@ -2047,7 +2047,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 44
       },
       "id": 2,
       "legend": {
@@ -2136,7 +2136,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 44
       },
       "id": 4,
       "legend": {
@@ -2224,7 +2224,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 51
       },
       "id": 6,
       "legend": {
@@ -2382,7 +2382,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 58
+        "y": 51
       },
       "id": 7,
       "legend": {
@@ -2503,7 +2503,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 58
+        "y": 51
       },
       "id": 22,
       "legend": {
@@ -2598,7 +2598,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 58
       },
       "id": 34,
       "panels": [],
@@ -2617,7 +2617,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 66
+        "y": 59
       },
       "id": 40,
       "legend": {
@@ -2704,7 +2704,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 66
+        "y": 59
       },
       "id": 44,
       "legend": {
@@ -2780,7 +2780,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 20,
   "style": "dark",
   "tags": [],
@@ -2808,5 +2808,5 @@
   "timezone": "",
   "title": "SAF Perf Test Dashboard",
   "uid": "J13LKTcZk",
-  "version": 2
+  "version": 4
 }


### PR DESCRIPTION
## Before

- New "Events Success Rate" gauge takes 1/4 of the "Test Indicators" row
- All the test indicators had been moved out of the row (could no longer be collapsed)
- Huge wasted whitespace to the right
![Screenshot from 2019-11-12 11-44-25](https://user-images.githubusercontent.com/5091372/68692139-f4b98200-0542-11ea-994a-2df4462cd6af.png)

## After
- Gauge is reasonable size
- Indicators back within the row
- Wasted space removed
- Changed title of "% of msgs QDR -> Prom" to say "% of metrics" instead to more clearly delineate.
![image](https://user-images.githubusercontent.com/5091372/68692360-5da0fa00-0543-11ea-8e83-ab3d0a76415d.png)

I have a whole host of tweaks I want to do to this dashboard (and this change is arguably not the nicest way to integrate the new gauge), but this one had me flip my lid the moment I saw it so I needed to propose a quick fix.