### PR TITLE
Eliminate 'bc' dependency from perftest script

### DIFF
--- a/tests/performance-test/performance-test.sh
+++ b/tests/performance-test/performance-test.sh
@@ -304,7 +304,7 @@ while true; do
             get_es_event_count
 
             # calulate success ratio
-            SUCCESS_RATIO=$(echo "scale=2; $ES_EVENT_RECV_COUNT / $NUM_COLLECTD_EVENTS" | bc -l | awk '{printf "%.2f", $0}')
+            SUCCESS_RATIO=$(( ES_EVENT_RECV_COUNT / NUM_COLLECTD_EVENTS)).$(( (ES_EVENT_RECV_COUNT * 100 / NUM_COLLECTD_EVENTS) % 100 ))
 
             # DEBUG and TESTING - DELETE 
             echo "EVENTS generated: $NUM_COLLECTD_EVENTS, recieved by Elastic Search: $ES_EVENT_RECV_COUNT, success rate: $SUCCESS_RATIO"


### PR DESCRIPTION
You don't know how lucky you are growing up in an era of fast floating point arithmetic! :smile: Shifting the decimal like this is a good tool to have in your pocket.

The test rig I've been using for perf testing didn't have `bc` installed. No biggie, but figured we could skip a `yum install` of this in our future automation. We should aggressively limit dependencies until all of this is containerized (if ever).