### PR TITLE
Trimming extra_stats list in infrared test harness

### DIFF
--- a/tests/infrared/metrics-collectd-qdr.yaml.template
+++ b/tests/infrared/metrics-collectd-qdr.yaml.template
@@ -25,7 +25,7 @@ custom_templates:
             collectd::plugin::interface::ignoreselected: true
             collectd::plugin::virt::connection: "qemu:///system"
             collectd::plugin::virt::hostname_format: "hostname uuid"
-            collectd::plugin::virt::extra_stats: "cpu_util disk disk_err domain_state pcpu fs_info job_stats_background perf vcpupin"
+            collectd::plugin::virt::extra_stats: "cpu_util disk disk_err pcpu job_stats_background perf vcpupin"
         MetricsQdrAddresses:
             - prefix: 'collectd'
               distribution: multicast


### PR DESCRIPTION
The fs_info extra_stats doesn't appear to work in the OSP deployment described by this automation. Collectd log shows:
```
[2019-11-12 21:31:30] virt plugin: virDomainGetFSInfo failed: -1
[2019-11-12 21:31:30] virt: Failed to get file system info
```
The plugin outputs no metrics.

After removing fs_info, the plugin started generating metrics, but also it seems the domain_state stat generates spam:
```
[2019-11-13 19:43:10] Notification: severity = OKAY, host = compute-0.localdomain:2066b66a-70c0-47d7-911a-7e8de613614d, plugin = virt, type = domain_state, message = Domain state: the domain is running. Reason: returned from paused state
[2019-11-13 19:43:11] Notification: severity = OKAY, host = compute-0.localdomain:2066b66a-70c0-47d7-911a-7e8de613614d, plugin = virt, type = domain_state, message = Domain state: the domain is running. Reason: returned from paused state
[2019-11-13 19:43:12] Notification: severity = OKAY, host = compute-0.localdomain:2066b66a-70c0-47d7-911a-7e8de613614d, plugin = virt, type = domain_state, message = Domain state: the domain is running. Reason: returned from paused state
[2019-11-13 19:43:13] Notification: severity = OKAY, host = compute-0.localdomain:2066b66a-70c0-47d7-911a-7e8de613614d, plugin = virt, type = domain_state, message = Domain state: the domain is running. Reason: returned from paused state
```
so I disabled that one too.