### PR TITLE
New supportable defaults for integration testing

### DIFF
--- a/tests/infrared/metrics-collectd-qdr.yaml.template
+++ b/tests/infrared/metrics-collectd-qdr.yaml.template
@@ -16,8 +16,6 @@ custom_templates:
             - ipmi
             - load
             - memory
-            - ovs_events
-            - ovs_stats
             - processes
             - unixsock
             - uptime

--- a/tests/infrared/metrics-collectd-qdr.yaml.template
+++ b/tests/infrared/metrics-collectd-qdr.yaml.template
@@ -4,28 +4,47 @@ tripleo_heat_templates:
 
 custom_templates:
     parameter_defaults:
-        CollectdAmqpInterval: 1
-        CollectdDefaultPollingInterval: 1
-        CollectdExtraPlugins:
+        CollectdAmqpInterval: 5
+        CollectdDefaultPollingInterval: 5
+        CollectdDefaultPlugins:
             - cpu
             - df
+            - disk
             - hugepages
+            - intel_rdt
+            - interface
+            - ipmi
+            - load
+            - memory
             - ovs_events
             - ovs_stats
-            - load
+            - processes
+            - unixsock
             - uptime
         DnsServers: ["10.19.42.41","10.11.5.19","10.5.30.160"]
         ExtraConfig:
-            collectd::plugin::cpu::valuespercentage: true
+            collectd::plugin::cpu::interval: 5
             collectd::plugin::cpu::reportbycpu: true
             collectd::plugin::cpu::reportbystate: true
             collectd::plugin::cpu::reportnumcpu: false
+            collectd::plugin::cpu::valuespercentage: true
+            collectd::plugin::df::interval: 300
             collectd::plugin::df::ignoreselected: true
+            collectd::plugin::df::fstypes: ['xfs']
+            collectd::plugin::disk::interval: 5
+            collectd::plugin::hugepages::interval: 60
+            collectd::plugin::intel_rdt::interval: 5
+            collectd::plugin::interface::interval: 5
+            collectd::plugin::ipmi::interval: 60
+            collectd::plugin::load::interval: 60
             collectd::plugin::load::reportrelative: true
-            collectd::plugin::interface::ignoreselected: true
+            collectd::plugin::memory::interval: 5
+            collectd::plugin::processes::interval: 5
+            collectd::plugin::uptime::interval: 60
+            collectd::plugin::virt::interval: 5
             collectd::plugin::virt::connection: "qemu:///system"
-            collectd::plugin::virt::hostname_format: "hostname uuid"
             collectd::plugin::virt::extra_stats: "cpu_util disk disk_err pcpu job_stats_background perf vcpupin"
+            collectd::plugin::virt::hostname_format: "hostname uuid"
         MetricsQdrAddresses:
             - prefix: 'collectd'
               distribution: multicast


### PR DESCRIPTION
* Setting these as reasonable defaults for integration testing
* Note the change from CollectdExtraPlugins to CollectdDefaultPlugins
  * This effectively overrides this list: https://github.com/openstack/tripleo-heat-templates/blob/master/deployment/metrics/collectd-container-puppet.yaml#L80
  * Adds: intel_rdt, ipmi, memory, ovs_events, ovs_stats
  * Removes: tcpconns
* This config produces <100 metrics/s/node
  * Down from ~1000 with the previous version of this file
  * Allows us the possibility of meeting the 100 nodes/cloud requirement
  * \# of VMs and network interfaces have the largest impact in production
* I wanted to explicitly set the interval of every plugin
  * Found that collectd::plugin::ovs_stats::interval does not work/exist
  * Adjusted overall interval to 5s as that's the lowest we use

**NOTE**: I really want to include the `virt` plugin here (It is included in the testing below) but I got triple-o errors when trying to deploy it to a non-compute node. I could use some help with the correct THT role implementation to selectively enable it here and upstream! 