### PR TITLE
Only enable CI testing for OCP3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: minimal
 sudo: required
 
+# 2019/12/12 - leifmadsen
+# until there is an `oc cluster up` equivalent for OKD 4, we're stuck needing
+# to disable CI until a work around is available
+branches:
+  only:
+    - saf-ocp3
+
 before_install:
 - tests/install-and-run-ocp.sh
 


### PR DESCRIPTION
Only enable our CI testing for changes going into the saf-ocp3 branch. Currently
required since we don't have access to an upstream OKD 4 instance that works via
the traditional 'oc cluster up' method. Only instantiation of clusters into AWS
is currently supported.