### PR TITLE
Update perftest dashboard to new pod names

### DIFF
--- a/tests/performance-test/grafana/perftest-dashboard.json
+++ b/tests/performance-test/grafana/perftest-dashboard.json
@@ -185,7 +185,7 @@
       "pluginVersion": "6.4.4",
       "targets": [
         {
-          "expr": "sum(count_over_time({exported_instance !~ \"saf-performance-test.*\", type =~ \".+\"}[$__range])) / sum(delta(deliveries_ingress{service=\"saf-default-interconnect\"}[$__range]))",
+          "expr": "sum(count_over_time({exported_instance !~ \"saf-perftest-.*-runner.*\", type =~ \".+\"}[$__range])) / sum(delta(deliveries_ingress{service=\"saf-default-interconnect\"}[$__range]))",
           "hide": false,
           "instant": true,
           "refId": "A"
@@ -1152,7 +1152,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(count_over_time({exported_instance !~ \"saf-performance-test.*\", type =~ \".+\"}[$__range]))",
+          "expr": "sum(count_over_time({exported_instance !~ \"saf-perftest-.*-runner.*\", type =~ \".+\"}[$__range]))",
           "hide": false,
           "instant": true,
           "refId": "A"
@@ -3108,8 +3108,8 @@
     "list": [
       {
         "current": {
-          "text": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-performance-test-.*|elasticsearch-cdm.*\"",
-          "value": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-performance-test-.*|elasticsearch-cdm.*\""
+          "text": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-perftest-.*|elasticsearch-cdm.*\"",
+          "value": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-perftest-.*|elasticsearch-cdm.*\""
         },
         "hide": 2,
         "label": "",
@@ -3117,11 +3117,11 @@
         "options": [
           {
             "selected": true,
-            "text": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-performance-test-.*|elasticsearch-cdm.*\"",
-            "value": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-performance-test-.*|elasticsearch-cdm.*\""
+            "text": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-perftest-.*|elasticsearch-cdm.*\"",
+            "value": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-perftest-.*|elasticsearch-cdm.*\""
           }
         ],
-        "query": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-performance-test-.*|elasticsearch-cdm.*\"",
+        "query": "pod_name=~\".*-smartgateway-.*|.*saf-default-interconnect-.*|qdr-test.*|prometheus-saf-default-0|saf-perftest-.*|elasticsearch-cdm.*\"",
         "skipUrlSync": false,
         "type": "constant"
       }


### PR DESCRIPTION
Awhile ago[1], I started to notice an error occasionally on the dashboard elements that count all the metrics in prometheus: "vector cannot contain metrics with the same labelset". It comes from the count_over_time() call, which takes a result set like this:

```
scrape_duration_seconds{endpoint="prom-http",instance="10.128.1.243:8081",job="saf-default-telemetry-smartgateway",namespace="sa-telemetry",pod="saf-default-telemetry-smartgateway-2-nss5q",service="saf-default-telemetry-smartgateway"}	0.001409569 @1576253970.625
0.001131969 @1576253971.625
scrape_duration_seconds{endpoint="prom-http",instance="10.128.1.244:8081",job="saf-default-telemetry-smartgateway",namespace="sa-telemetry",pod="saf-default-telemetry-smartgateway-2-n24sv",service="saf-default-telemetry-smartgateway"}	0.001969405 @1576253970.372
0.001553855 @1576253971.372
scrape_duration_seconds{endpoint="web",instance="10.128.1.216:9090",job="prometheus-operated",namespace="sa-telemetry",pod="prometheus-saf-default-0",service="prometheus-operated"}	0.0059735 @1576253969.884
0.00591912 @1576253970.884
```

and turns it into this:

```
{endpoint="prom-http",instance="10.128.1.243:8081",job="saf-default-telemetry-smartgateway",namespace="sa-telemetry",pod="saf-default-telemetry-smartgateway-2-nss5q",service="saf-default-telemetry-smartgateway"}	2
{endpoint="prom-http",instance="10.128.1.244:8081",job="saf-default-telemetry-smartgateway",namespace="sa-telemetry",pod="saf-default-telemetry-smartgateway-2-n24sv",service="saf-default-telemetry-smartgateway"}	2
{endpoint="web",instance="10.128.1.216:9090",job="prometheus-operated",namespace="sa-telemetry",pod="prometheus-saf-default-0",service="prometheus-operated"}	2
```

As you can see, the resulting vector has no sample names anymore, just the labelsets because this sort of query is INTENDED to be used on single metrics (It's crazy bad for performance to query ALL metrics, you'd never do it in production!)

The problem comes when you actually have two metric names with the same exact labelset, like this (actual example of what was breaking):

```
sa_collectd_metrics000_type0_samples_total{endpoint="prom-http",exported_instance="saf-perftest-1-hostname000",metrics000="pluginInst0",service="saf-default-telemetry-smartgateway",type="typInst0"}	0.2686
sa_collectd_telemetry_bench_simulate_expected_metrics_per_interval{endpoint="prom-http",exported_instance="saf-perftest-1-runner-lqmb7",service="saf-default-telemetry-smartgateway",telemetry_bench="1576253961",type="1"}	1
sa_collectd_telemetry_bench_simulate_interval_length_seconds{endpoint="prom-http",exported_instance="saf-perftest-1-runner-lqmb7",service="saf-default-telemetry-smartgateway",telemetry_bench="1576253961",type="1"}	1
sa_collectd_telemetry_bench_simulate_intervals{endpoint="prom-http",exported_instance="saf-perftest-1-runner-lqmb7",service="saf-default-telemetry-smartgateway",telemetry_bench="1576253961",type="1"}	60
```

There are three (perfectly valid!) metrics with the exact same labelset. They happen to be generated by the test bench itself to help with instrumenting and evaluating tests, and previously they were filtered out based on the exported_instance name, which prevented this error.

In a production environment with production metrics, I expect problems with this:

1. This query is very heavy on prometheus. The larger the time range and the more metrics, the more heavy it is.
1. In the real world, it's pretty common to have multiple metrics with the same labelset

For testing, these queries are extremely important, but if we ever want to integrate this dashboard into the production product (to help users monitor SAF itself, which I think is a great idea!) then we'll need an on/off switch for the graphs that count metrics like this. Or perhaps we can find a better way to do the counts?

[1]https://trello.com/c/hcUaltNb/813-migrate-telemetry-framework-perftest-to-work-with-saf2#comment-5ddc3cca94779a586e68eca6"