### PR TITLE
Update quickstart.sh for new application registry

### DIFF
--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -46,12 +46,12 @@ spec:
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: service-assurance-operator
+  name: serviceassurance-operator-alpha-redhat-service-assurance-operators-openshift-marketplace
   namespace: ${SAF_PROJECT}
 spec:
   channel: alpha
   installPlanApproval: Automatic
-  name: service-assurance-operator
+  name: serviceassurance-operator
   source: redhat-service-assurance-operators
   sourceNamespace: openshift-marketplace
   startingCSV: service-assurance-operator.v0.1.0


### PR DESCRIPTION
We changed the name and path of the application and container registries in order
to avoid named registries. This change updates the quickstart.sh to account for this
change so that a Service Assurance deployment results.

Name of the Subscription has been updated to reflect the pattern that OLM created
for other dependent Subscriptions of the SAO. Updated spec.name to account for the
new package name.