### PR TITLE
Disable events in main quickstart

### DIFF
--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -65,5 +65,5 @@ metadata:
   namespace: ${SAF_PROJECT}
 spec:
   metricsEnabled: true
-  eventsEnabled: true
+  eventsEnabled: false
 EOF


### PR DESCRIPTION
You need to use the ES workaround version for it to work anyways: https://github.com/redhat-service-assurance/telemetry-framework/blob/master/deploy/quickstart_ESworkaround.sh

This also matches the defaults in the SAO: https://github.com/redhat-service-assurance/service-assurance-operator/blob/49e11e5242cfe1debe42da352f12c50659dd4dd9/roles/serviceassurance/defaults/main.yml#L4